### PR TITLE
stty: fix typo

### DIFF
--- a/pages/common/stty.md
+++ b/pages/common/stty.md
@@ -17,7 +17,7 @@
 
 - Get the actual transfer speed of a device:
 
-`stty -f {{path/to/device_file}} speed`
+`stty -F {{path/to/device_file}} speed`
 
 - Reset all modes to reasonable values for the current terminal:
 


### PR DESCRIPTION
According to stty --help, parameter F must be capital (small is not recognized).
Some Asian translation appears to have the same error, but I didn't want to break encoding.

<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and mark all the boxes accordingly. -->
<!-- You can remove the checklist items that don't apply to your PR. -->

- [V ] The page (if new), does not already exist in the repo.
- [ V] The page is in the correct platform directory (`common/`, `linux/`, etc.)
- [ V] The page has 8 or fewer examples.
- [V ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message).
- [ V] The page follows the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ V The page description includes a link to documentation or a homepage (if applicable).
